### PR TITLE
Fix readthedocs build

### DIFF
--- a/examples/import_osmnx/import_osmnx.py
+++ b/examples/import_osmnx/import_osmnx.py
@@ -2,7 +2,11 @@ import os
 
 import geopandas as gpd
 import matplotlib.pyplot as plt
-import osmnx as ox
+
+try:
+    import osmnx as ox
+except ImportError:
+    print("Need to install osmnx to run this example")
 
 import dhnx
 

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
         'pillow',
         'geopandas',
         'folium',
-        'osmnx',
         'addict',
     ],
     extras_require={
         'cartopy': ['cartopy'],
+        'osmnx' : ['osmnx'],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     ],
     extras_require={
         'cartopy': ['cartopy'],
-        'osmnx' : ['osmnx'],
+        'osmnx': ['osmnx'],
     }
 )


### PR DESCRIPTION
Moved osmnx to extra requires. This fixes the build on readthedocs (#9).

TODO:
* [x] Add a warning in the osm example