### PR TITLE
Define __repr__() method

### DIFF
--- a/dhnx/network.py
+++ b/dhnx/network.py
@@ -79,6 +79,19 @@ class ThermalNetwork():
             except ImportError:
                 print('Failed to import file.')
 
+    def __repr__(self):
+        r"""
+        This method defines what is returned if you perform print() or str()
+        on a ThermalNetwork.
+        """
+        summary = ''
+        for component, data in self.components.items():
+            count = len(data)
+            if count > 0:
+                summary += '  ' + str(count) + ' ' + component + '\n'
+
+        return f"dhnx.network.ThermalNetwork object containing:\n{summary}"
+
     def from_csv_folder(self, dirname):
         importer = CSVNetworkImporter(self, dirname)
 

--- a/dhnx/network.py
+++ b/dhnx/network.py
@@ -88,9 +88,12 @@ class ThermalNetwork():
         for component, data in self.components.items():
             count = len(data)
             if count > 0:
-                summary += '  ' + str(count) + ' ' + component + '\n'
+                summary += ' * ' + str(count) + ' ' + component + '\n'
 
-        return f"dhnx.network.ThermalNetwork object containing:\n{summary}"
+        if summary == '':
+            return f"empty dhnx.network.ThermalNetwork object containing no components"
+
+        return f"dhnx.network.ThermalNetwork object with these components\n{summary}"
 
     def from_csv_folder(self, dirname):
         importer = CSVNetworkImporter(self, dirname)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -19,6 +19,14 @@ Create a thermal network
 
     thermal_network.add('Edge', id=0, from_node='producer-0', to_node='consumer-0')
 
+    print(thermal_network)
+
+    # returns
+    # dhnx.network.ThermalNetwork object with these components
+    #  * 1 producers
+    #  * 1 consumers
+    #  * 1 edges
+
     print(thermal_network.components.edges)
 
     # returns


### PR DESCRIPTION
This PR adds a `__repr__()` method to the ThermalNetwork class. This allows you to print() a ThermalNetwork and get the following:

``` python
thermal_network = dhnx.network.ThermalNetwork()

print(thermal_network)

# empty dhnx.network.ThermalNetwork object containing no components

thermal_network.add('Producer', id=0)

print(thermal_network)

# dhnx.network.ThermalNetwork object with these components
#  * 1 producers

```