### PR TITLE
Remove ThermalNetwork from components

### DIFF
--- a/dhnx/components.csv
+++ b/dhnx/components.csv
@@ -1,5 +1,4 @@
 component_class,list_name,description
-ThermalNetwork,thermal_networks,"Container for all components belonging to one thermal network"
 ThermalSubNetwork,thermal_sub_networks,"Subsets of a thermal network"
 Producer,producers,"Heat producer"
 Consumer,consumers,"Heat consumer"


### PR DESCRIPTION
ThermalNetwork is part of the component list (see e.g. in the table here https://dhnx.readthedocs.io/en/latest/network.html#thermal-network), as described also in #33. This is confusing. Also, ThermalNetwork does not has attributes described in component_atts. As a solution, this PR removes it from components.csv.