### PR TITLE
Expose solver cmdline options dict setting to user

### DIFF
--- a/dhnx/optimization.py
+++ b/dhnx/optimization.py
@@ -407,8 +407,10 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
             s_kw = self.settings['solve_kw']
 
         logging.info('Solve the optimization problem')
-        self.om.solve(solver=self.settings['solver'],
-                      solve_kwargs=s_kw)
+        self.om.solve(
+            solver=self.settings['solver'],
+            solve_kwargs=s_kw,
+            cmdline_options=self.settings.get('solver_cmdline_options', {}))
 
         if self.settings['write_lp_file']:
             filename = os.path.join(
@@ -635,9 +637,10 @@ def optimize_operation(thermal_network):
 
 
 def setup_optimise_investment(
-        thermal_network, invest_options, heat_demand='scalar', num_ts=1, time_res=1,
-        start_date='1/1/2018', frequence='H', solver='cbc', solve_kw=None,
-        simultaneity=1, bidirectional_pipes=False, dump_path=None, dump_name='dump.oemof',
+        thermal_network, invest_options, heat_demand='scalar', num_ts=1,
+        time_res=1, start_date='1/1/2018', frequence='H', solver='cbc',
+        solve_kw=None, solver_cmdline_options={}, simultaneity=1,
+        bidirectional_pipes=False, dump_path=None, dump_name='dump.oemof',
         print_logging_info=False, write_lp_file=False):
     """
     Function for setting up the oemof solph operational Model.
@@ -663,6 +666,8 @@ def setup_optimise_investment(
         Name of solver.
     solve_kw : dict
         Solver kwargs.
+    solver_cmdline_options : dict
+        Dictionary with command line options for solver.
     simultaneity : float
         Simultaneity factor.
     bidirectional_pipes : bool
@@ -694,6 +699,7 @@ def setup_optimise_investment(
         'frequence': frequence,
         'solver': solver,
         'solve_kw': solve_kw,
+        'solver_cmdline_options': solver_cmdline_options,
         'simultaneity': simultaneity,
         'bidirectional_pipes': bidirectional_pipes,
         'dump_path': dump_path,

--- a/dhnx/optimization.py
+++ b/dhnx/optimization.py
@@ -639,7 +639,7 @@ def optimize_operation(thermal_network):
 def setup_optimise_investment(
         thermal_network, invest_options, heat_demand='scalar', num_ts=1,
         time_res=1, start_date='1/1/2018', frequence='H', solver='cbc',
-        solve_kw=None, solver_cmdline_options={}, simultaneity=1,
+        solve_kw=None, solver_cmdline_options=None, simultaneity=1,
         bidirectional_pipes=False, dump_path=None, dump_name='dump.oemof',
         print_logging_info=False, write_lp_file=False):
     """
@@ -690,6 +690,9 @@ def setup_optimise_investment(
         raise ValueError(
             'The settings attribute *heat_demand* must be "scalar" or "series"!'
         )
+
+    if solver_cmdline_options is None:
+        solver_cmdline_options = {}
 
     settings = {
         'heat_demand': heat_demand,


### PR DESCRIPTION
Currently, it is not possible to send command line options to the solver. ``self.om.solve()`` offers the parameter ``cmdline_options``, but it is not used. This PR exposes the ``cmdline_options`` to the user, to be used e.g.  in the following way:

```Python

settings = dict(solver='cbc',
                solve_kw={
                    'tee': True,  # print solver output
                },
                solver_cmdline_options={
                    # 'allowableGap': 1e-5,  # default: 1e-10
                    'ratioGap': 1e-2,  # default: 0
                    'seconds': 60*10,  # default: 1e+100
                    },
                )

network.optimize_investment(invest_options=invest_opt, **settings)
```

Closes #55 