### PR TITLE
Fix/no bidirectional consumer connection

### DIFF
--- a/dhnx/optimization.py
+++ b/dhnx/optimization.py
@@ -263,8 +263,7 @@ class OemofInvestOptimizationModel(InvestOptimizationModel):
                 to_frame(name='P_heat_max')
 
             self.thermal_network.components['consumers'] = \
-                pd.concat([self.thermal_network.components['consumers'], df_max],
-                          axis=1, join='outer', sort=False)
+                self.thermal_network.components['consumers'].join(df_max)
 
         # check, which optimization type should be performed
         if self.settings['heat_demand'] == 'scalar':

--- a/dhnx/optimization_add_components.py
+++ b/dhnx/optimization_add_components.py
@@ -347,7 +347,7 @@ def add_storage(it, labels, nodes, busd):
     return nodes
 
 
-def add_heatpipes(it, labels, bidi, q, b_in, b_out, nodes):
+def add_heatpipes(it, labels, bidirectional, q, b_in, b_out, nodes):
     """
     Adds *HeatPipeline* objects with *Investment* attribute to the list of oemof.solph components.
 
@@ -387,7 +387,7 @@ def add_heatpipes(it, labels, bidi, q, b_in, b_out, nodes):
         # bidirectional heatpipelines yes or no
         flow_bi_args = {
             'bidirectional': True, 'min': -1}\
-            if bidi else {}
+            if bidirectional else {}
 
         nodes.append(oh.HeatPipeline(
             label=oh.Label(labels['l_1'], labels['l_2'],

--- a/dhnx/optimization_add_components.py
+++ b/dhnx/optimization_add_components.py
@@ -347,7 +347,7 @@ def add_storage(it, labels, nodes, busd):
     return nodes
 
 
-def add_heatpipes(it, labels, gd, q, b_in, b_out, nodes):
+def add_heatpipes(it, labels, bidi, q, b_in, b_out, nodes):
     """
     Adds *HeatPipeline* objects with *Investment* attribute to the list of oemof.solph components.
 
@@ -357,8 +357,8 @@ def add_heatpipes(it, labels, gd, q, b_in, b_out, nodes):
         Table of *Heatpipeline* attributes of the district heating grid
     labels : dict
         Dictonary containing specifications for label-tuple
-    gd : dict
-        Settings of the investment optimisation of the ThermalNetwork
+    bidi : bool
+        Settings for creating bidirectional heatpipelines
     q : pd.Series
         Specific *Pipe* of ThermalNetwork
     b_in : oemof.solph.Bus
@@ -387,7 +387,7 @@ def add_heatpipes(it, labels, gd, q, b_in, b_out, nodes):
         # bidirectional heatpipelines yes or no
         flow_bi_args = {
             'bidirectional': True, 'min': -1}\
-            if gd['bidirectional_pipes'] else {}
+            if bidi else {}
 
         nodes.append(oh.HeatPipeline(
             label=oh.Label(labels['l_1'], labels['l_2'],

--- a/dhnx/optimization_add_components.py
+++ b/dhnx/optimization_add_components.py
@@ -347,7 +347,7 @@ def add_storage(it, labels, nodes, busd):
     return nodes
 
 
-def add_heatpipes(it, labels, bidirectional, q, b_in, b_out, nodes):
+def add_heatpipes(it, labels, bidirectional, length, b_in, b_out, nodes):
     """
     Adds *HeatPipeline* objects with *Investment* attribute to the list of oemof.solph components.
 
@@ -359,8 +359,8 @@ def add_heatpipes(it, labels, bidirectional, q, b_in, b_out, nodes):
         Dictonary containing specifications for label-tuple
     bidirectional : bool
         Settings for creating bidirectional heatpipelines
-    q : pd.Series
-        Specific *Pipe* of ThermalNetwork
+    length : float
+        Length of pipeline
     b_in : oemof.solph.Bus
         Bus of Inflow
     b_out : oemof.solph.Bus
@@ -378,8 +378,8 @@ def add_heatpipes(it, labels, bidirectional, q, b_in, b_out, nodes):
         # definition of tag3 of label -> type of pipe
         labels['l_3'] = t['label_3']
 
-        epc_p = t['capex_pipes'] * q['length']
-        epc_fix = t['fix_costs'] * q['length']
+        epc_p = t['capex_pipes'] * length
+        epc_fix = t['fix_costs'] * length
 
         # Heatpipe with binary variable
         nc = bool(t['nonconvex'])
@@ -400,8 +400,8 @@ def add_heatpipes(it, labels, bidirectional, q, b_in, b_out, nodes):
                     ep_costs=epc_p, maximum=t['cap_max'],
                     minimum=t['cap_min'], nonconvex=nc, offset=epc_fix,
                 ))},
-            heat_loss_factor=t['l_factor'] * q['length'],
-            heat_loss_factor_fix=t['l_factor_fix'] * q['length'],
+            heat_loss_factor=t['l_factor'] * length,
+            heat_loss_factor_fix=t['l_factor_fix'] * length,
         ))
 
     return nodes

--- a/dhnx/optimization_add_components.py
+++ b/dhnx/optimization_add_components.py
@@ -357,7 +357,7 @@ def add_heatpipes(it, labels, bidi, q, b_in, b_out, nodes):
         Table of *Heatpipeline* attributes of the district heating grid
     labels : dict
         Dictonary containing specifications for label-tuple
-    bidi : bool
+    bidirectional : bool
         Settings for creating bidirectional heatpipelines
     q : pd.Series
         Specific *Pipe* of ThermalNetwork

--- a/dhnx/optimization_dhs_nodes.py
+++ b/dhnx/optimization_dhs_nodes.py
@@ -143,7 +143,7 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                 d_labels['l_4'] = start + '-' + end
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, False, q, b_in, b_out,
+                    pipe_data, d_labels, False, q['length'], b_in, b_out,
                     nodes)
 
             elif q['from_node'].split('-')[0] == "consumers":
@@ -162,7 +162,7 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
 
                 nodes = ac.add_heatpipes(
                     pipe_data, d_labels,
-                    gd['bidirectional_pipes'], q, b_in, b_out,
+                    gd['bidirectional_pipes'], q['length'], b_in, b_out,
                     nodes)
 
             elif q['from_node'].split('-')[0] == "producers":
@@ -175,7 +175,7 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                 d_labels['l_4'] = start + '-' + end
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, gd['bidirectional_pipes'], q, b_in, b_out,
+                    pipe_data, d_labels, gd['bidirectional_pipes'], q['length'], b_in, b_out,
                     nodes)
 
             elif (q['from_node'].split('-')[0] == 'forks') and (
@@ -186,7 +186,7 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                 d_labels['l_4'] = q['from_node'] + '-' + q['to_node']
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, gd['bidirectional_pipes'], q, b_in, b_out, nodes)
+                    pipe_data, d_labels, gd['bidirectional_pipes'], q['length'], b_in, b_out, nodes)
 
                 if not gd['bidirectional_pipes']:
                     # the heatpipes from fork to fork need to be created in
@@ -197,7 +197,9 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                     d_labels['l_4'] = q['to_node'] + '-' + q['from_node']
 
                     nodes = ac.add_heatpipes(
-                        pipe_data, d_labels, gd['bidirectional_pipes'], q, b_in, b_out, nodes)
+                        pipe_data, d_labels, gd['bidirectional_pipes'], q['length'], b_in, b_out,
+                        nodes
+                    )
 
             else:
                 raise ValueError("Something wrong!")

--- a/dhnx/optimization_dhs_nodes.py
+++ b/dhnx/optimization_dhs_nodes.py
@@ -175,8 +175,9 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                 d_labels['l_4'] = start + '-' + end
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, gd['bidirectional_pipes'], q['length'], b_in, b_out,
-                    nodes)
+                    pipe_data, d_labels, gd['bidirectional_pipes'], q['length'],
+                    b_in, b_out, nodes,
+                )
 
             elif (q['from_node'].split('-')[0] == 'forks') and (
                     q['to_node'].split('-')[0] == 'forks'):

--- a/dhnx/optimization_dhs_nodes.py
+++ b/dhnx/optimization_dhs_nodes.py
@@ -135,8 +135,6 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
             # connection of houses
             if q['to_node'].split('-')[0] == "consumers":
 
-                bidi = False
-
                 start = q['from_node']
                 end = q['to_node']
                 b_in = busd[(d_labels['l_1'], d_labels['l_2'], 'bus', start)]
@@ -145,7 +143,7 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                 d_labels['l_4'] = start + '-' + end
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, bidi, q, b_in, b_out,
+                    pipe_data, d_labels, False, q, b_in, b_out,
                     nodes)
 
             elif q['from_node'].split('-')[0] == "consumers":
@@ -154,8 +152,6 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                     " Existing heatpipe id {}".format(p))
 
             elif q['to_node'].split('-')[0] == "producers":
-
-                bidi = False
 
                 start = q['to_node']
                 end = q['from_node']
@@ -166,12 +162,10 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
 
                 nodes = ac.add_heatpipes(
                     pipe_data, d_labels,
-                    bidi, q, b_in, b_out,
+                    gd['bidirectional_pipes'], q, b_in, b_out,
                     nodes)
 
             elif q['from_node'].split('-')[0] == "producers":
-
-                bidi = False
 
                 start = q['from_node']
                 end = q['to_node']
@@ -181,20 +175,18 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                 d_labels['l_4'] = start + '-' + end
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, bidi, q, b_in, b_out,
+                    pipe_data, d_labels, gd['bidirectional_pipes'], q, b_in, b_out,
                     nodes)
 
             elif (q['from_node'].split('-')[0] == 'forks') and (
                     q['to_node'].split('-')[0] == 'forks'):
-
-                bidi = gd['bidirectional_pipes']
 
                 b_in = busd[(d_labels['l_1'], d_labels['l_2'], 'bus', q['from_node'])]
                 b_out = busd[(d_labels['l_1'], d_labels['l_2'], 'bus', q['to_node'])]
                 d_labels['l_4'] = q['from_node'] + '-' + q['to_node']
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, bidi, q, b_in, b_out, nodes)
+                    pipe_data, d_labels, gd['bidirectional_pipes'], q, b_in, b_out, nodes)
 
                 if not gd['bidirectional_pipes']:
                     # the heatpipes from fork to fork need to be created in
@@ -205,7 +197,7 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                     d_labels['l_4'] = q['to_node'] + '-' + q['from_node']
 
                     nodes = ac.add_heatpipes(
-                        pipe_data, d_labels, bidi, q, b_in, b_out, nodes)
+                        pipe_data, d_labels, gd['bidirectional_pipes'], q, b_in, b_out, nodes)
 
             else:
                 raise ValueError("Something wrong!")

--- a/dhnx/optimization_dhs_nodes.py
+++ b/dhnx/optimization_dhs_nodes.py
@@ -135,6 +135,8 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
             # connection of houses
             if q['to_node'].split('-')[0] == "consumers":
 
+                bidi = False
+
                 start = q['from_node']
                 end = q['to_node']
                 b_in = busd[(d_labels['l_1'], d_labels['l_2'], 'bus', start)]
@@ -143,7 +145,7 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                 d_labels['l_4'] = start + '-' + end
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, gd, q, b_in, b_out,
+                    pipe_data, d_labels, bidi, q, b_in, b_out,
                     nodes)
 
             elif q['from_node'].split('-')[0] == "consumers":
@@ -152,6 +154,8 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                     " Existing heatpipe id {}".format(p))
 
             elif q['to_node'].split('-')[0] == "producers":
+
+                bidi = False
 
                 start = q['to_node']
                 end = q['from_node']
@@ -162,10 +166,12 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
 
                 nodes = ac.add_heatpipes(
                     pipe_data, d_labels,
-                    gd, q, b_in, b_out,
+                    bidi, q, b_in, b_out,
                     nodes)
 
             elif q['from_node'].split('-')[0] == "producers":
+
+                bidi = False
 
                 start = q['from_node']
                 end = q['to_node']
@@ -175,18 +181,20 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                 d_labels['l_4'] = start + '-' + end
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, gd, q, b_in, b_out,
+                    pipe_data, d_labels, bidi, q, b_in, b_out,
                     nodes)
 
             elif (q['from_node'].split('-')[0] == 'forks') and (
                     q['to_node'].split('-')[0] == 'forks'):
+
+                bidi = gd['bidirectional_pipes']
 
                 b_in = busd[(d_labels['l_1'], d_labels['l_2'], 'bus', q['from_node'])]
                 b_out = busd[(d_labels['l_1'], d_labels['l_2'], 'bus', q['to_node'])]
                 d_labels['l_4'] = q['from_node'] + '-' + q['to_node']
 
                 nodes = ac.add_heatpipes(
-                    pipe_data, d_labels, gd, q, b_in, b_out, nodes)
+                    pipe_data, d_labels, bidi, q, b_in, b_out, nodes)
 
                 if not gd['bidirectional_pipes']:
                     # the heatpipes from fork to fork need to be created in
@@ -197,7 +205,7 @@ def add_nodes_dhs(opti_network, gd, nodes, busd):
                     d_labels['l_4'] = q['to_node'] + '-' + q['from_node']
 
                     nodes = ac.add_heatpipes(
-                        pipe_data, d_labels, gd, q, b_in, b_out, nodes)
+                        pipe_data, d_labels, bidi, q, b_in, b_out, nodes)
 
             else:
                 raise ValueError("Something wrong!")

--- a/docs/whatsnew/v0-0-2.rst
+++ b/docs/whatsnew/v0-0-2.rst
@@ -26,7 +26,7 @@ Documentation
 Bug fixes
 ^^^^^^^^^^^^^^^^^^^^
 
-* something
+* Avoid bidirectional flow at consumers connections in any case.
 
 Known issues
 ^^^^^^^^^^^^^^^^^^^^
@@ -46,4 +46,4 @@ Other changes
 Contributors
 ^^^^^^^^^^^^^^^^^^^^
 
-* something
+* Johannes Röder


### PR DESCRIPTION
Bug: If the setting `bidirectional_pipes=True` is selected, also the connecting line to the building was created as bidirectional.

This only matters if a source or a storage is added at the consumers.

This PR fixes the issue.