### PR TITLE
Fix deprecations in dependencies shapely 1.8.0 and pandas 1.4.1

### DIFF
--- a/dhnx/gistools/geometry_operations.py
+++ b/dhnx/gistools/geometry_operations.py
@@ -24,7 +24,7 @@ try:
     from shapely.geometry import LineString
     from shapely.geometry import MultiLineString
     from shapely.geometry import Point
-    from shapely.ops import cascaded_union
+    from shapely.ops import unary_union
     from shapely.ops import linemerge
     from shapely.ops import nearest_points
 except ImportError:
@@ -51,18 +51,17 @@ def create_forks(lines):
     Returns
     -------
     geopandas.GeoDataFrame : GeoDataFrame with Points as geometry.
-    """
 
-    nodes = gpd.GeoDataFrame()
+    """
+    nodes = gpd.GeoDataFrame(geometry=[], crs=lines.crs)
 
     for _, j in lines.iterrows():
         geom = j['geometry']
-        p_0 = Point(geom.boundary[0])
-        p_1 = Point(geom.boundary[-1])
-        nodes = nodes.append({'geometry': p_0}, ignore_index=True)
-        nodes = nodes.append({'geometry': p_1}, ignore_index=True)
-
-    nodes.crs = lines.crs
+        p_0 = Point(geom.boundary.geoms[0])
+        p_1 = Point(geom.boundary.geoms[-1])
+        nodes = pd.concat(
+            [nodes, gpd.GeoDataFrame(geometry=[p_0, p_1], crs=lines.crs)],
+            ignore_index=True)
 
     # transform geometry into wkt
     nodes["geometry_wkt"] = nodes["geometry"].apply(lambda geom: geom.wkt)
@@ -103,8 +102,8 @@ def insert_node_ids(lines, nodes):
 
     # add id to gdf_lines for starting and ending node
     # point as wkt
-    lines['b0_wkt'] = lines["geometry"].apply(lambda geom: geom.boundary[0].wkt)
-    lines['b1_wkt'] = lines["geometry"].apply(lambda geom: geom.boundary[-1].wkt)
+    lines['b0_wkt'] = lines["geometry"].apply(lambda geom: geom.boundary.geoms[0].wkt)
+    lines['b1_wkt'] = lines["geometry"].apply(lambda geom: geom.boundary.geoms[-1].wkt)
 
     lines['from_node'] = lines['b0_wkt'].apply(lambda x: nodes.at[x, 'id_full'])
     lines['to_node'] = lines['b1_wkt'].apply(lambda x: nodes.at[x, 'id_full'])
@@ -141,7 +140,7 @@ def check_double_points(gdf, radius=0.001, id_column=None):
 
         point = c['geometry']
         gdf_other = gdf.drop([r])
-        other_points = cascaded_union(gdf_other['geometry'])
+        other_points = unary_union(gdf_other['geometry'])
 
         # x1 = nearest_points(point, other_points)[0]
         x2 = nearest_points(point, other_points)[1]
@@ -214,13 +213,13 @@ def split_multilinestr_to_linestr(gdf_input):
             for multiline in multilinestrings:
                 new_row = b.copy()
                 new_row['geometry'] = multiline
-                new_lines = new_lines.append(
-                    new_row, ignore_index=True, sort=False)
+                new_lines = pd.concat([new_lines, new_row.to_frame().T],
+                                      ignore_index=True, sort=False)
 
             gdf_lines.drop(index=i, inplace=True)
 
-    gdf_lines = gdf_lines.append(
-        new_lines, ignore_index=True, sort=False)
+    gdf_lines = pd.concat([gdf_lines, new_lines], ignore_index=True,
+                          sort=False)
 
     gdf_lines['geometry'].crs = gdf_input.crs
 
@@ -238,13 +237,13 @@ def split_multilinestr_to_linestr(gdf_input):
                 new_row = b.copy()
                 new_row['geometry'] = \
                     LineString([geom.coords[num], geom.coords[num + 1]])
-                new_lines = new_lines.append(
-                    new_row, ignore_index=True, sort=False)
+                new_lines = pd.concat([new_lines, new_row.to_frame().T],
+                                      ignore_index=True, sort=False)
 
             gdf_lines.drop(index=i, inplace=True)
 
-    gdf_lines = gdf_lines.append(
-        new_lines, ignore_index=True, sort=False)
+    gdf_lines = pd.concat([gdf_lines, new_lines], ignore_index=True,
+                          sort=False)
 
     gdf_lines['geometry'].crs = gdf_input.crs
 
@@ -357,8 +356,8 @@ def _weld_segments(gdf_line_net, gdf_line_gen, gdf_line_houses,
 
             # Test if one end touches a 'external' line, while the other
             # end touches touches a network line segment
-            p1 = geom.boundary[0]
-            p2 = geom.boundary[-1]
+            p1 = geom.boundary.geoms[0]
+            p2 = geom.boundary.geoms[-1]
             p1_neighbours = [p1.intersects(g) for g in neighbours.geometry]
             p2_neighbours = [p2.intersects(g) for g in neighbours.geometry]
             if any_check(p1, gdf_line_ext, how='touches') and p2_neighbours.count(True) > 0:
@@ -369,12 +368,13 @@ def _weld_segments(gdf_line_net, gdf_line_gen, gdf_line_houses,
             if unused:
                 # If truly unused, we can discard it to simplify the network
                 debug_plot(neighbours, color='white')
-                gdf_deleted = gdf_deleted.append(b, ignore_index=True)
+                gdf_deleted = pd.concat(
+                    [gdf_deleted, b.to_frame().T], ignore_index=True)
             else:
                 # Keep it, if it touches a generator or a house
                 debug_plot(neighbours, color='black')
-                gdf_line_net_new = gdf_line_net_new.append(
-                    b, ignore_index=True)
+                gdf_line_net_new = pd.concat(
+                    [gdf_line_net_new, b.to_frame().T], ignore_index=True)
             continue  # Continue with the next line segment
 
         if len(neighbours) > 2:
@@ -382,8 +382,8 @@ def _weld_segments(gdf_line_net, gdf_line_gen, gdf_line_houses,
             # part of an intersection, which we do not simplify futher.
             # However, we can check if either endpoint of the current segment
             # only has one neighbour. Then that one can still be merged.
-            p1 = geom.boundary[0]
-            p2 = geom.boundary[-1]
+            p1 = geom.boundary.geoms[0]
+            p2 = geom.boundary.geoms[-1]
             p1_neighbours = [p1.intersects(g) for g in neighbours.geometry]
             p2_neighbours = [p2.intersects(g) for g in neighbours.geometry]
             if p1_neighbours.count(True) == 1:  # Only one neighbour allowed
@@ -391,8 +391,8 @@ def _weld_segments(gdf_line_net, gdf_line_gen, gdf_line_houses,
             elif p2_neighbours.count(True) == 1:  # Only one neighbour allowed
                 neighbours = neighbours[p2_neighbours]  # Neighbour to merge
             else:  # Keep this segment. Multiple lines meet at an intersection
-                gdf_line_net_new = gdf_line_net_new.append(b,
-                                                           ignore_index=True)
+                gdf_line_net_new = pd.concat(
+                    [gdf_line_net_new, b.to_frame().T], ignore_index=True)
                 debug_plot(neighbours, color='green')
                 continue  # Continue with the next line segment
 
@@ -424,7 +424,8 @@ def _weld_segments(gdf_line_net, gdf_line_gen, gdf_line_houses,
 
         if len(neighbours) == 0:
             # If no neighbours are left now, continue with next line segment
-            gdf_line_net_new = gdf_line_net_new.append(b, ignore_index=True)
+            gdf_line_net_new = pd.concat(
+                [gdf_line_net_new, b.to_frame().T], ignore_index=True)
             continue
 
         # Create list of all elements that should be merged
@@ -447,9 +448,10 @@ def _weld_segments(gdf_line_net, gdf_line_gen, gdf_line_houses,
         gdf_merged = gpd.GeoDataFrame(geometry=[merged_line])
         debug_plot(neighbours)  # Plot the segments before the merge
         debug_plot(gdf_merged, color='orange')  # ...and after the merge
-        gdf_line_net_new = gdf_line_net_new.append(gdf_merged,
-                                                   ignore_index=True)
-        gdf_merged_all = gdf_merged_all.append(gdf_merged, ignore_index=True)
+        gdf_line_net_new = pd.concat([gdf_line_net_new, gdf_merged],
+                                     ignore_index=True)
+        gdf_merged_all = pd.concat([gdf_merged_all, gdf_merged],
+                                   ignore_index=True)
 
     return gdf_line_net_new
 


### PR DESCRIPTION
Upgrading to shapely 1.8.0 and pandas 1.4.1 causes an actual error and lots of warnings in dhnx example scripts. This PR is an attempt to fix as many of those as possible.

Fixes #84

The the related issue #84 for detailed description of the issues and fixes.