### PR TITLE
Implement pressure loss calculation via pandapipes

### DIFF
--- a/docs/whatsnew/v0-1-0.rst
+++ b/docs/whatsnew/v0-1-0.rst
@@ -40,6 +40,16 @@ API changes
     found, there will be a warning.
 
 
+* Implemented pressure loss calculation via pandapipes
+
+  * When calling ``delta_p()``, ``v_max_secant()`` and ``v_max_bisection()``
+    from the ``precalc_hydraulic`` module, users can now choose pandapipes
+    as the calculation method for the pressure loss of a pipe. This is done
+    by setting ``calculation="pandapipes"``. Additional ``kwargs`` like
+    ``friction_model`` can be passed to the pandapipes calculation.
+    Requires installing ``pip install pandapipes`` separately. The default
+    setting is the existing ``calculation="internal"``.
+
 New features
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ Changelog = "https://dhnx.readthedocs.io/en/latest/whats_new.html"
 ]
 "hydraulic" = [
     "CoolProp",
+    "pandapipes",
 ]
 
 [tool.black]

--- a/src/dhnx/optimization/precalc_hydraulic.py
+++ b/src/dhnx/optimization/precalc_hydraulic.py
@@ -331,6 +331,82 @@ def delta_p(
     pressure=101325,
     R_crit=2320,
     fluid="IF97::Water",
+    calculation="internal",
+    **kwargs,
+):
+    r"""
+    Function to calculate the pressure loss in a pipeline
+
+    Parameters
+    ----------
+    v : numeric
+        :math:`v`: flow velocity [m/s]
+
+    d_i : numeric
+        :math:`d_i`: inner pipe diameter [m]
+
+    k : numeric
+        :math:`k`: roughness of inner pipeline surface [mm]
+
+    T_medium : numeric
+        :math:`T_{medium}`: fluid temperature [°C]
+
+    length : numeric
+        :math:`l`: length of the pipe [m]
+
+    pressure : numeric
+        :math:`p`: pressure in the pipe [Pa]
+
+    R_crit : numeric
+        :math:`Re_{crit}`: critical Reynolds number between laminar and
+        turbulent flow [-]. Only used for ``calculation="internal"``.
+
+    fluid : str
+        name of the fluid used
+
+    calculation: str
+        Type of calculation, default: "internal". If "pandapipes" is chosen,
+        the pandapipes module is used for the calculation of the pressure drop.
+
+    **kwargs: dict
+        Additional keyword arguments for the selected external calculation.
+        For pandapipes, e.g. 'friction_model' can be specified.
+
+    Returns
+    -------
+    Pressure drop [Pa] : numeric
+
+    """
+    if calculation == "internal":
+        d_p = delta_p_internal(
+            v, d_i, k, T_medium, length, pressure, R_crit, fluid
+        )
+
+    elif calculation == "pandapipes":
+        if fluid == "IF97::Water":
+            fluid = "water"
+        d_p = delta_p_pandapipes(
+            v, d_i, k, T_medium, length, pressure, fluid, **kwargs
+        )
+
+    else:
+        raise ValueError(
+            "Invalid calculation type '{calculation}'. Choose 'internal' "
+            "or 'pandapipes'."
+        )
+
+    return d_p
+
+
+def delta_p_internal(
+    v,
+    d_i,
+    k=0.1,
+    T_medium=90,
+    length=1,
+    pressure=101325,
+    R_crit=2320,
+    fluid="IF97::Water",
 ):
     r"""
     Function to calculate the pressure loss in a pipeline
@@ -410,6 +486,87 @@ def delta_p(
     return d_p
 
 
+def delta_p_pandapipes(
+    v,
+    d_i,
+    k,
+    T_medium,
+    length,
+    pressure,
+    fluid="water",
+    friction_model="colebrook",
+    **kwargs,
+):
+    """Use external module 'pandapipes' to calculate pressure drop in a pipe.
+
+    The most basic pandapipes 'network' with a single water pipe is
+    created and simulated.
+
+    Parameters
+    ----------
+    v : numeric
+        :math:`v`: flow velocity [m/s]
+
+    d_i : numeric
+        :math:`d_i`: inner pipe diameter [m]
+
+    k : numeric
+        :math:`k`: roughness of inner pipeline surface [mm]
+
+    T_medium : numeric
+        :math:`T_{medium}`: fluid temperature [°C]
+
+    length : numeric
+        :math:`l`: length of the pipe [m]
+
+    pressure : numeric
+        :math:`p`: pressure in the pipe [Pa]
+
+    fluid : str
+        name of the fluid used
+
+    friction_model : str
+        Friction model to be used in pandapipes. Default: "colebrook"
+
+    **kwargs: dict
+        Additional keyword arguments for the pandapipes calculation.
+
+    Returns
+    -------
+    Pressure drop [Pa] : numeric
+    """
+    import pandapipes as pp
+
+    p_bar = pressure / 1e5  # Pa to bar
+    tfluid_k = T_medium + 273.15
+    pp_net = pp.create_empty_network(fluid=fluid)
+    rho = pp_net.fluid.get_density(tfluid_k)
+    mdot = rho * v * (0.5 * d_i) ** 2 * math.pi  # kg/s
+
+    js = pp.create_junctions(
+        pp_net, nr_junctions=2, pn_bar=p_bar, tfluid_k=tfluid_k
+    )
+    pp.create_ext_grid(pp_net, junction=js[0], p_bar=p_bar, t_k=tfluid_k)
+    pp.create_sink(net=pp_net, junction=js[1], mdot_kg_per_s=mdot)
+    pp.create_pipe_from_parameters(
+        net=pp_net,
+        from_junction=js[0],
+        to_junction=js[1],
+        length_km=length / 1000,  # convert m to km
+        inner_diameter_mm=d_i * 1000,  # convert m to mm
+        k_mm=k,
+    )
+
+    pp.pipeflow(
+        pp_net, mode="hydraulics", friction_model=friction_model, **kwargs
+    )
+
+    dp_bar = (pp_net.res_pipe.p_from_bar - pp_net.res_pipe.p_to_bar).loc[0]
+    dp_pa = dp_bar * 1e5  # bar to Pa
+
+    return dp_pa
+
+
 def calc_v(vol_flow, d_i):
     r"""
     Calculates the velocity for a given volume flow and inner diameter
@@ -445,6 +602,8 @@ def v_max_secant(
     v_1=2,
     pressure=101325,
     fluid="IF97::Water",
+    calculation="internal",
+    **kwargs,
 ):
     r"""Calculates the maximum velocity via iterative approach
     using the secant method.
@@ -483,6 +642,14 @@ def v_max_secant(
     fluid: str
         type of fluid, default: 'IF97::Water'
 
+    calculation: str
+        Type of calculation, default: 'internal'. If 'pandapipes' is chosen,
+        the pandapipes module is used for the calculation of the pressure drop.
+
+    **kwargs: dict
+        Additional keyword arguments for the selected external calculation.
+        For pandapipes, e.g. 'friction_model' can be specified.
+
     Returns
     -------
     maximum flow velocity [m/s] : numeric
@@ -501,6 +668,8 @@ def v_max_secant(
             T_medium=T_average,
             pressure=pressure,
             fluid=fluid,
+            calculation=calculation,
+            **kwargs,
         )
 
         p_1 = delta_p(
@@ -510,6 +679,8 @@ def v_max_secant(
             T_medium=T_average,
             pressure=pressure,
             fluid=fluid,
+            calculation=calculation,
+            **kwargs,
         )
 
         v_new = v_1 - (p_1 - p_max) * (v_1 - v_0) / (p_1 - p_0)
@@ -521,6 +692,8 @@ def v_max_secant(
             T_medium=T_average,
             pressure=pressure,
             fluid=fluid,
+            calculation=calculation,
+            **kwargs,
         )
 
         if abs(p_new - p_max) < p_epsilon:
@@ -550,6 +723,8 @@ def v_max_bisection(
     v_1=10,
     pressure=101325,
     fluid="IF97::Water",
+    calculation="internal",
+    **kwargs,
 ):
     r"""Calculates the maximum velocity via bisection for a
     given pressure drop.
@@ -595,17 +770,39 @@ def v_max_bisection(
     fluid: str
         type of fluid, default: 'IF97::Water'
 
+    calculation: str
+        Type of calculation, default: 'internal'. If 'pandapipes' is chosen,
+        the pandapipes module is used for the calculation of the pressure drop.
+
+    **kwargs: dict
+        Additional keyword arguments for the selected external calculation.
+        For pandapipes, e.g. 'friction_model' can be specified.
+
     Returns
     -------
     maximum flow velocity [m/s] : numeric
 
     """
     p_0 = delta_p(
-        v_0, k=k, d_i=d_i, T_medium=T_average, pressure=pressure, fluid=fluid
+        v_0,
+        k=k,
+        d_i=d_i,
+        T_medium=T_average,
+        pressure=pressure,
+        fluid=fluid,
+        calculation=calculation,
+        **kwargs,
     )
 
     p_1 = delta_p(
-        v_1, k=k, d_i=d_i, T_medium=T_average, pressure=pressure, fluid=fluid
+        v_1,
+        k=k,
+        d_i=d_i,
+        T_medium=T_average,
+        pressure=pressure,
+        fluid=fluid,
+        calculation=calculation,
+        **kwargs,
     )
 
     if (p_0 - p_max) * (p_1 - p_max) >= 0:
@@ -627,6 +824,8 @@ def v_max_bisection(
             T_medium=T_average,
             pressure=pressure,
             fluid=fluid,
+            calculation=calculation,
+            **kwargs,
         )
 
         p_1 = delta_p(
@@ -636,6 +835,8 @@ def v_max_bisection(
             T_medium=T_average,
             pressure=pressure,
             fluid=fluid,
+            calculation=calculation,
+            **kwargs,
         )
 
         v_new = 0.5 * (v_1 + v_0)
@@ -647,6 +848,8 @@ def v_max_bisection(
             T_medium=T_average,
             pressure=pressure,
             fluid=fluid,
+            calculation=calculation,
+            **kwargs,
         )
 
         if abs(p_new - p_max) < p_epsilon:

--- a/tests/test_precalc_hydraulic.py
+++ b/tests/test_precalc_hydraulic.py
@@ -159,3 +159,13 @@ def test_delta_p5():  # turb, Re*k/di > 1300
 def test_delta_p6():  # turb, transition
     dp = delta_p(100, 5e-3, k=0.0003)
     assert round(dp, 5) == 11865210.59373
+
+
+def test_delta_p_pandapipes():
+    dp = delta_p(2, 0.2, k=0.01, pressure=2e5, calculation="pandapipes")
+    assert round(dp, 5) == 119.33562
+
+
+def test_delta_p_calculation_undefined():
+    with pytest.raises(ValueError, match="Invalid calculation type"):
+        delta_p(2, 0.2, k=0.01, pressure=2e5, calculation="undefined")

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ passenv =
 deps =
     py
     pytest
+    pandapipes
 extras =
     dev
     gis

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ passenv =
 deps =
     py
     pytest
-    pandapipes
 extras =
     dev
     gis


### PR DESCRIPTION
I have added a new argument ``calculation`` to ``delta_p()`` and the functions which call it (``v_max_secant()``, ``v_max_bisection()``) which allows using a ``pandapipes`` simulation to calculate pressure losses in a pipe as an alternative to the existing internal implementation.

* [x] Update code
* [x] Add new test
* [x] Update changelog
* ~Update documentation~

Fixes #162

## Context
dhnx includes the ``precalc_hydraulic`` module which allows converting the resulting capacity of each pipe into norm diameters.
For this, a pressure loss calculation is needed, for which ``precalc_hydraulic`` provides an internal solution.

In my workflows, I design a network with dhnx and then run a simulation of temperature and pressure distribution with pandapipes to check if the network is valid in terms of pressure drops and velocities. In some rare edge cases I noticed differences where dhnx was supposed to only give e.g. a maximum of 100 Pa/m pressure losses in any given pipe segment but pandapipes showed slightly larger values.

Implementing a new function ``delta_p_pandapipes()`` in ``precalc_hydraulic`` solved the issue because it synchronizes the precalculation and post-processing. It allows calculating the pressure loss with pandapipes instead of using the internal implementation.

Independently, in #162 another user describes issues with the internal implementation. Instead of trying to fix/improve the internal pressure loss equations I think it is the best approach to use external modules that have already put more resources into this problem. (Nevertheless: pandapipes itself offers different friction models, and judging by the issues there, not all of them are perfect, either.)

## Considerations / feedback

* My approach gives room to add other calculation methods in the future, which may coexist. I hope that is useful
* Running ``pandapipes`` is significantly slower than the internal method. But in the context of a long optimization procedure that is fine
* ``precalc_hydraulic`` is briefly mentioned in the documentation, but not actually documented. Thus there was no documentation to update
* I have added matching tests
* In order for the new test to work, I have added ``pandapipes`` to the deps in testenv in ``tox.ini``. But I am unsure if this is the best way and I need feedback. I guess I could create a new entry of optional dependencies in ``pyproject.toml`` instead, but that feels like overkill to me. If a user knows they want to use pandapipes alongside dhnx, they can just install it.
* ``pandapipes`` requires ``pandapower``, which is currently still restricted to ``pandas<3.0``. Thus with this change all of our tests here will run with ``pandas 2.x``, which is not ideal, I think. But I see no way around that. Thoughts?